### PR TITLE
[redux-form] Fix error prop type in InjectedFormProps

### DIFF
--- a/types/redux-form/lib/reduxForm.d.ts
+++ b/types/redux-form/lib/reduxForm.d.ts
@@ -79,7 +79,7 @@ export interface InjectedFormProps<FormData = {}, P = {}> {
     clearAsyncError(field: string): void;
     destroy(): void;
     dirty: boolean;
-    error: string;
+    error: any;
     form: string;
     handleSubmit: SubmitHandler<FormData, P>;
     initialize(data: Partial<FormData>): void;


### PR DESCRIPTION
The documentation of redux-form indicates that the error prop should be `any`. 



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://redux-form.com/7.0.3/docs/api/props.md/#-code-error-any-code-
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

